### PR TITLE
fix model data access

### DIFF
--- a/R/progenySuppFunc.r
+++ b/R/progenySuppFunc.r
@@ -187,9 +187,9 @@ getModel <- function(organism = "Human", top= 100) {
     pathway <- p.value <- weight <- NULL
 
     if (organism == "Human") {
-        full_model <- get("model_human_full", envir = .GlobalEnv)
+        full_model <- model_human_full
     } else if (organism == "Mouse") {
-        full_model <- get("model_mouse_full", envir = .GlobalEnv)
+        full_model <- model_mouse_full
     } else {
         stop("Wrong organism name. Please specify 'Human' or 'Mouse'.")
     }


### PR DESCRIPTION
This should allow to use `progeny::progeny` if `progeny` is not attached (`library(progeny)` has not been called)